### PR TITLE
feat: add better-auth skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "next": "15.4.5",
-    "@prisma/client": "^5.15.0"
+    "@prisma/client": "^5.15.0",
+    "better-auth": "1.3.4"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,8 +7,74 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
+enum RoleName {
+  USER
+  ADMIN
+  SUPERADMIN
+}
+
+model Role {
+  id          Int          @id @default(autoincrement())
+  name        RoleName     @unique
+  users       User[]
+  permissions Permission[] @relation("RolePermissions")
+}
+
+model Permission {
   id    Int    @id @default(autoincrement())
-  email String @unique
-  name  String?
+  name  String @unique
+  roles Role[] @relation("RolePermissions")
+}
+
+model User {
+  id       String    @id @default(cuid())
+  email    String    @unique
+  name     String?
+  password String?
+  roleId   Int?
+  role     Role?     @relation(fields: [roleId], references: [id])
+  accounts Account[]
+  sessions Session[]
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model PasswordResetToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
 }

--- a/src/app/api/auth/[...better-auth]/route.ts
+++ b/src/app/api/auth/[...better-auth]/route.ts
@@ -1,0 +1,3 @@
+import { auth } from "@/lib/auth";
+
+export const { GET, POST } = auth;

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,8 @@
+export default function ForgotPasswordPage() {
+  return (
+    <form action="/api/auth/forgot-password" method="post" className="flex flex-col gap-2">
+      <input type="email" name="email" placeholder="Email" className="border p-2" />
+      <button type="submit" className="bg-blue-500 text-white p-2">Send reset link</button>
+    </form>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+export default function LoginPage() {
+  return (
+    <div className="flex flex-col gap-4">
+      <form action="/api/auth/signin" method="post" className="flex flex-col gap-2">
+        <input type="email" name="email" placeholder="Email" className="border p-2" />
+        <input type="password" name="password" placeholder="Password" className="border p-2" />
+        <button type="submit" className="bg-blue-500 text-white p-2">Sign In</button>
+      </form>
+      <form action="/api/auth/google" method="post">
+        <button type="submit" className="underline">Sign in with Google</button>
+      </form>
+      <a href="/forgot-password" className="underline">Forgot password?</a>
+      <a href="/register" className="underline">Register</a>
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,10 @@
+export default function RegisterPage() {
+  return (
+    <form action="/api/auth/signup" method="post" className="flex flex-col gap-2">
+      <input type="text" name="name" placeholder="Name" className="border p-2" />
+      <input type="email" name="email" placeholder="Email" className="border p-2" />
+      <input type="password" name="password" placeholder="Password" className="border p-2" />
+      <button type="submit" className="bg-blue-500 text-white p-2">Register</button>
+    </form>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { google } from "better-auth/providers/google";
+import { email } from "better-auth/providers/email";
+import { prisma } from "./prisma";
+
+export const auth = betterAuth({
+  adapter: prismaAdapter(prisma),
+  providers: [
+    google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    email({})
+  ],
+  emails: {
+    send: async () => {
+      // Integrate with email provider to send verification and reset emails
+    }
+  },
+  session: {
+    strategy: "jwt"
+  }
+});

--- a/types/better-auth.d.ts
+++ b/types/better-auth.d.ts
@@ -1,0 +1,18 @@
+declare module "better-auth" {
+  export function betterAuth(config: any): any;
+}
+
+declare module "better-auth/adapters/prisma" {
+  const prismaAdapter: (client: any) => any;
+  export { prismaAdapter };
+}
+
+declare module "better-auth/providers/google" {
+  const google: (options: any) => any;
+  export { google };
+}
+
+declare module "better-auth/providers/email" {
+  const email: (options: any) => any;
+  export { email };
+}


### PR DESCRIPTION
## Summary
- add better-auth auth configuration with Google and email providers
- expand Prisma schema for roles, permissions, and auth tables
- scaffold login, register, and forgot-password pages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_688cf797c93883278678781a88bb5312